### PR TITLE
Add DATABASE_URL configuration to database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV["DATABASE_URL"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
This pull request includes an update to the database configuration file to use an environment variable for the database URL.

* [`config/database.yml`](diffhunk://#diff-5a674c769541a71f2471a45c0e9dde911b4455344e3131bddc5a363701ba6325R5): Added `url` parameter to the `default` configuration to use the `DATABASE_URL` environment variable.